### PR TITLE
Update email templates

### DIFF
--- a/emails/class-finishing-email.php
+++ b/emails/class-finishing-email.php
@@ -54,6 +54,7 @@ class Finishing_Email extends WC_Email {
         foreach ( $items as $item_key => $item_value ) {
             // add an event for the item email, pass the item ID so other details can be collected as needed
             wp_schedule_single_event( time(), 'custom_finishing_email_trigger', array( 'item_id' => $item_key ) );
+            break;
         }
     }
 

--- a/emails/class-finishing-email.php
+++ b/emails/class-finishing-email.php
@@ -18,7 +18,7 @@ class Finishing_Email extends WC_Email {
         $this->title                = __( 'Finishing Email', 'finishing-email' );
         $this->description          = __( 'This email is received when an order status is changed to "Receiving".', 'finishing-email' );
 
-        $this->heading              = __( 'Finishing Email', 'finishing-email' );
+        $this->heading              = __( 'Finishing', 'finishing-email' );
         $this->subject              = __( '[{blogname}] Order for {product_title} (Order {order_number}) - {order_date}', 'finishing-email' );
 
         // email template path

--- a/emails/class-pony-email.php
+++ b/emails/class-pony-email.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Finishing Email
+ *
+ * An email class for custom "Pony" emails
+ *
+ * @class       Pony_Email
+ * @extends     WC_Email
+ *
+ */
+class Pony_Email extends WC_Email {
+
+    function __construct() {
+
+        // Add email ID, title, description, heading, subject
+        $this->id                   = 'pony_email';
+        $this->customer_email       = true;
+        $this->title                = __( 'Pony Email', 'pony-email' );
+        $this->description          = __( 'This email is received when an order status is changed to "Pony".', 'pony-email' );
+
+        $this->heading              = __( 'Thanks for using VTA Document Services', 'pony-email' );
+        $this->subject              = __( '[{blogname}] Order for {product_title} (Order {order_number}) - {order_date}', 'pony-email' );
+
+        // email template path
+        $this->template_html    = 'emails/pony-email-html.php';
+        $this->template_plain   = 'emails/plain/pony-email-plain.php';
+
+        // Triggers for this email
+        add_action( 'custom_pony_email_notification', array( $this, 'queue_notification' ) );
+        add_action( 'custom_pony_email_trigger_notification', array( $this, 'trigger' ) );
+
+        // Call parent constructor
+        parent::__construct();
+
+        // Other settings
+        $this->template_base = CUSTOM_TEMPLATE_PATH;
+        // default recipient to null. This field will be set when trigger pulls order information
+        // and sets it to customer email
+        $this->recipient     = null;
+        // placeholders for form fields
+        $this->placeholders  = array(
+            '{order_date}'              => '',
+            '{order_number}'            => '',
+            '{order_billing_full_name}' => '',
+        );
+
+    }
+
+    public function queue_notification( $order_id ) {
+
+        $order = new WC_order( $order_id );
+        $items = $order->get_items();
+        // foreach item in the order
+        foreach ( $items as $item_key => $item_value ) {
+            // add an event for the item email, pass the item ID so other details can be collected as needed
+            wp_schedule_single_event( time(), 'custom_pony_email_trigger', array( 'item_id' => $item_key ) );
+            break;
+        }
+    }
+
+    // This function collects the data and sends the email
+    function trigger( $item_id ) {
+
+        $send_email = true;
+        // validations
+        if ( $item_id && $send_email ) {
+            // create an object with item details like name, quantity etc.
+            $this->object = $this->create_object( $item_id );
+
+            // replace the merge tags with valid data
+            $key = array_search( '{product_title}', $this->find );
+            if ( false !== $key ) {
+                unset( $this->find[ $key ] );
+                unset( $this->replace[ $key ] );
+            }
+
+            $this->find[]    = '{product_title}';
+            $this->replace[] = $this->object->product_title;
+
+            if ( $this->object->order_id ) {
+
+                $this->find[]    = '{order_date}';
+                $this->replace[] = date_i18n( wc_date_format(), strtotime( $this->object->order_date ) );
+
+                $this->find[]    = '{order_number}';
+                $this->replace[] = $this->object->order_id;
+            } else {
+
+                $this->find[]    = '{order_date}';
+                $this->replace[] = __( 'N/A', 'pony-email' );
+
+                $this->find[]    = '{order_number}';
+                $this->replace[] = __( 'N/A', 'pony-email' );
+            }
+
+            // if no recipient is set, do not send the email
+            if ( ! $this->get_recipient() ) {
+                return;
+            }
+            // send the email
+            $this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(),
+                array() );
+
+        }
+    }
+
+    // Create an object with the data to be passed to the templates
+    public function create_object( $item_id ) {
+
+        global $wpdb;
+
+        $item_object = new stdClass();
+
+        // order ID
+        $query_order_id = "SELECT order_id FROM `". $wpdb->prefix."woocommerce_order_items`
+                            WHERE order_item_id = %d";
+        $get_order_id = $wpdb->get_results( $wpdb->prepare( $query_order_id, $item_id ) );
+
+        $order_id = 0;
+        if ( isset( $get_order_id ) && is_array( $get_order_id ) && count( $get_order_id ) > 0 ) {
+            $order_id = $get_order_id[0]->order_id;
+        }
+        $item_object->order_id = $order_id;
+
+        $order               = new WC_order( $order_id );
+        $this->recipient     = $order->get_billing_email();
+
+        // order date
+        $post_data = get_post( $order_id );
+        $item_object->order_date = $post_data->post_date;
+
+        // product ID
+        $item_object->product_id = wc_get_order_item_meta( $item_id, '_product_id' );
+
+        // product name
+        $_product = wc_get_product( $item_object->product_id );
+        $item_object->product_title = $_product->get_title();
+
+        // qty
+        $item_object->qty = wc_get_order_item_meta( $item_id, '_qty' );
+
+        // total
+        $item_object->total = wc_price( wc_get_order_item_meta( $item_id, '_line_total' ) );
+
+        // email adress
+        $item_object->billing_email = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_email : $order->get_billing_email();
+
+        // customer ID
+        $item_object->customer_id = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->user_id : $order->get_user_id();
+
+        return $item_object;
+
+    }
+
+    // return the html content
+    function get_content_html() {
+        ob_start();
+        wc_get_template( $this->template_html, array(
+            'item_data'       => $this->object,
+            'email_heading' => $this->get_heading(),
+            'additional_content' => $this->get_additional_content()
+        ), 'custom-templates', $this->template_base );
+        return ob_get_clean();
+    }
+
+    // return the plain content
+    function get_content_plain() {
+        ob_start();
+        wc_get_template( $this->template_plain, array(
+            'item_data'       => $this->object,
+            'email_heading' => $this->get_heading(),
+            'additional_content' => $this->get_additional_content()
+        ), 'custom-templates', $this->template_base );
+        return ob_get_clean();
+    }
+
+    // return the subject
+    function get_subject() {
+
+        $order = new WC_order( $this->object->order_id );
+        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $this->subject ), $this->object );
+
+    }
+
+    // return the email heading
+    public function get_heading() {
+
+        $order = new WC_order( $this->object->order_id );
+        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $this->heading ), $this->object );
+
+    }
+
+    // form fields that are displayed in WooCommerce->Settings->Emails
+    function init_form_fields() {
+        $placeholder_text  = sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>' . esc_html( implode( '</code>, <code>', array_keys( $this->placeholders ) ) ) . '</code>' );
+        $this->form_fields = array(
+            'enabled' => array(
+                'title' 		=> __( 'Enable/Disable', 'pony-email' ),
+                'type' 			=> 'checkbox',
+                'label' 		=> __( 'Enable this email notification', 'pony-email' ),
+                'default' 		=> 'yes'
+            ),
+            'subject' => array(
+                'title' 		=> __( 'Subject', 'pony-email' ),
+                'type' 			=> 'text',
+                'description' 	=> sprintf( __( 'This controls the email subject line. Leave blank to use the default subject: <code>%s</code>.', 'pony-email' ), $this->subject ),
+                'placeholder' 	=> '',
+                'default' 		=> ''
+            ),
+            'heading' => array(
+                'title' 		=> __( 'Email Heading', 'pony-email' ),
+                'type' 			=> 'text',
+                'description' 	=> sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>.', 'pony-email' ), $this->heading ),
+                'placeholder' 	=> '',
+                'default' 		=> ''
+            ),
+            'additional_content' => array(
+                'title'       => __( 'Additional content', 'pony-email' ),
+                'description' => __( 'Text to appear below the main email content.', 'pony-email' ) . ' ' .
+                    $placeholder_text,
+                'css'         => 'width:400px; height: 75px;',
+                'placeholder' => __( 'N/A', 'pony-email' ),
+                'type'        => 'textarea',
+                'default'     => $this->get_default_additional_content(),
+                'desc_tip'    => true,
+            ),
+            'email_type' => array(
+                'title' 		=> __( 'Email type', 'pony-email' ),
+                'type' 			=> 'select',
+                'description' 	=> __( 'Choose which format of email to send.', 'pony-email' ),
+                'default' 		=> 'html',
+                'class'			=> 'email_type',
+                'options'		=> array(
+                    'plain'		 	=> __( 'Plain text', 'pony-email' ),
+                    'html' 			=> __( 'HTML', 'pony-email' ),
+                    'multipart' 	=> __( 'Multipart', 'pony-email' ),
+                )
+            )
+        );
+    }
+
+}
+return new Pony_Email();
+?>

--- a/emails/class-proof-ready-email.php
+++ b/emails/class-proof-ready-email.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Custom Email
+ *
+ * A template email for how customer emails should follow
+ *
+ * @class       Custom_Email
+ * @extends     WC_Email
+ *
+ */
+class Proof_Ready_Email extends WC_Email {
+
+    function __construct() {
+
+        // Add email ID, title, description, heading, subject
+        $this->id                   = 'proof_ready_email';
+        $this->customer_email       = true;
+        $this->title                = __( 'Proof Ready Email', 'proof-ready-email' );
+        $this->description          = __( 'This email is received when an order status is changed to Pending.', 'proof-ready-email' );
+
+        $this->heading              = __( 'Proof Ready', 'proof-ready-email' );
+        $this->subject              = __( '[{blogname}] Order for {product_title} (Order {order_number}) - {order_date}', 'proof-ready-email' );
+
+        // email template path
+        $this->template_html    = 'emails/proof-ready-email-html.php';
+        $this->template_plain   = 'emails/plain/proof-ready-email-plain.php';
+
+        // Triggers for this email
+        add_action( 'custom_proof_email_notification', array( $this, 'queue_notification' ) );
+        add_action( 'custom_proof_email_trigger_notification', array( $this, 'trigger' ) );
+
+        // Call parent constructor
+        parent::__construct();
+
+        // Other settings
+        $this->template_base = CUSTOM_TEMPLATE_PATH;
+        // default recipient to null. This field will be set when trigger pulls order information
+        // and sets it to customer email
+        $this->recipient     = null;
+        // placeholders for form fields
+        $this->placeholders  = array(
+            '{order_date}'              => '',
+            '{order_number}'            => '',
+            '{order_billing_full_name}' => '',
+        );
+
+    }
+
+    public function queue_notification( $order_id ) {
+
+        $order = new WC_order( $order_id );
+        $items = $order->get_items();
+        // foreach item in the order
+        foreach ( $items as $item_key => $item_value ) {
+            // add an event for the item email, pass the item ID so other details can be collected as needed
+            wp_schedule_single_event( time(), 'custom_proof_email_trigger', array( 'item_id' => $item_key ) );
+        }
+    }
+
+    // This function collects the data and sends the email
+    function trigger( $item_id ) {
+
+        $send_email = true;
+        // validations
+        if ( $item_id && $send_email ) {
+            // create an object with item details like name, quantity etc.
+            $this->object = $this->create_object( $item_id );
+
+            // replace the merge tags with valid data
+            $key = array_search( '{product_title}', $this->find );
+            if ( false !== $key ) {
+                unset( $this->find[ $key ] );
+                unset( $this->replace[ $key ] );
+            }
+
+            $this->find[]    = '{product_title}';
+            $this->replace[] = $this->object->product_title;
+
+            if ( $this->object->order_id ) {
+
+                $this->find[]    = '{order_date}';
+                $this->replace[] = date_i18n( wc_date_format(), strtotime( $this->object->order_date ) );
+
+                $this->find[]    = '{order_number}';
+                $this->replace[] = $this->object->order_id;
+            } else {
+
+                $this->find[]    = '{order_date}';
+                $this->replace[] = __( 'N/A', 'proof-ready-email' );
+
+                $this->find[]    = '{order_number}';
+                $this->replace[] = __( 'N/A', 'proof-ready-email' );
+            }
+
+            // if no recipient is set, do not send the email
+            if ( ! $this->get_recipient() ) {
+                return;
+            }
+            // send the email
+            $this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(),
+                array() );
+
+        }
+    }
+
+    // Create an object with the data to be passed to the templates
+    public function create_object( $item_id ) {
+
+        global $wpdb;
+
+        $item_object = new stdClass();
+
+        // order ID
+        $query_order_id = "SELECT order_id FROM `". $wpdb->prefix."woocommerce_order_items`
+                            WHERE order_item_id = %d";
+        $get_order_id = $wpdb->get_results( $wpdb->prepare( $query_order_id, $item_id ) );
+
+        $order_id = 0;
+        if ( isset( $get_order_id ) && is_array( $get_order_id ) && count( $get_order_id ) > 0 ) {
+            $order_id = $get_order_id[0]->order_id;
+        }
+        $item_object->order_id = $order_id;
+
+        $order               = new WC_order( $order_id );
+        $this->recipient     = $order->get_billing_email();
+
+        // order date
+        $post_data = get_post( $order_id );
+        $item_object->order_date = $post_data->post_date;
+
+        // product ID
+        $item_object->product_id = wc_get_order_item_meta( $item_id, '_product_id' );
+
+        // product name
+        $_product = wc_get_product( $item_object->product_id );
+        $item_object->product_title = $_product->get_title();
+
+        // qty
+        $item_object->qty = wc_get_order_item_meta( $item_id, '_qty' );
+
+        // total
+        $item_object->total = wc_price( wc_get_order_item_meta( $item_id, '_line_total' ) );
+
+        // email adress
+        $item_object->billing_email = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_email : $order->get_billing_email();
+
+        // customer ID
+        $item_object->customer_id = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->user_id : $order->get_user_id();
+
+        return $item_object;
+
+    }
+
+    // return the html content
+    function get_content_html() {
+        ob_start();
+        wc_get_template( $this->template_html, array(
+            'item_data'       => $this->object,
+            'email_heading' => $this->get_heading(),
+            'additional_content' => $this->get_additional_content()
+        ), 'custom-templates', $this->template_base );
+        return ob_get_clean();
+    }
+
+    // return the plain content
+    function get_content_plain() {
+        ob_start();
+        wc_get_template( $this->template_plain, array(
+            'item_data'       => $this->object,
+            'email_heading' => $this->get_heading(),
+            'additional_content' => $this->get_additional_content()
+        ), 'custom-templates', $this->template_base );
+        return ob_get_clean();
+    }
+
+    // return the subject
+    function get_subject() {
+
+        $order = new WC_order( $this->object->order_id );
+        return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $this->subject ), $this->object );
+
+    }
+
+    // return the email heading
+    public function get_heading() {
+
+        $order = new WC_order( $this->object->order_id );
+        return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $this->heading ), $this->object );
+
+    }
+
+    // form fields that are displayed in WooCommerce->Settings->Emails
+    function init_form_fields() {
+        $placeholder_text  = sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>' . esc_html( implode( '</code>, <code>', array_keys( $this->placeholders ) ) ) . '</code>' );
+        $this->form_fields = array(
+            'enabled' => array(
+                'title' 		=> __( 'Enable/Disable', 'proof-ready-email' ),
+                'type' 			=> 'checkbox',
+                'label' 		=> __( 'Enable this email notification', 'proof-ready-email' ),
+                'default' 		=> 'yes'
+            ),
+            'subject' => array(
+                'title' 		=> __( 'Subject', 'proof-ready-email' ),
+                'type' 			=> 'text',
+                'description' 	=> sprintf( __( 'This controls the email subject line. Leave blank to use the default subject: <code>%s</code>.', 'proof-ready-email' ), $this->subject ),
+                'placeholder' 	=> '',
+                'default' 		=> ''
+            ),
+            'heading' => array(
+                'title' 		=> __( 'Email Heading', 'proof-ready-email' ),
+                'type' 			=> 'text',
+                'description' 	=> sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>.', 'proof-ready-email' ), $this->heading ),
+                'placeholder' 	=> '',
+                'default' 		=> ''
+            ),
+            'additional_content' => array(
+                'title'       => __( 'Additional content', 'proof-ready-email' ),
+                'description' => __( 'Text to appear below the main email content.', 'proof-ready-email' ) . ' ' .
+                    $placeholder_text,
+                'css'         => 'width:400px; height: 75px;',
+                'placeholder' => __( 'N/A', 'proof-ready-email' ),
+                'type'        => 'textarea',
+                'default'     => $this->get_default_additional_content(),
+                'desc_tip'    => true,
+            ),
+            'email_type' => array(
+                'title' 		=> __( 'Email type', 'proof-ready-email' ),
+                'type' 			=> 'select',
+                'description' 	=> __( 'Choose which format of email to send.', 'proof-ready-email' ),
+                'default' 		=> 'html',
+                'class'			=> 'email_type',
+                'options'		=> array(
+                    'plain'		 	=> __( 'Plain text', 'proof-ready-email' ),
+                    'html' 			=> __( 'HTML', 'proof-ready-email' ),
+                    'multipart' 	=> __( 'Multipart', 'proof-ready-email' ),
+                )
+            )
+        );
+    }
+
+}
+return new Proof_Ready_Email();
+?>

--- a/emails/class-proof-ready-email.php
+++ b/emails/class-proof-ready-email.php
@@ -54,6 +54,7 @@ class Proof_Ready_Email extends WC_Email {
         foreach ( $items as $item_key => $item_value ) {
             // add an event for the item email, pass the item ID so other details can be collected as needed
             wp_schedule_single_event( time(), 'custom_proof_email_trigger', array( 'item_id' => $item_key ) );
+            break;
         }
     }
 

--- a/emails/class-ready-for-pickup-email.php
+++ b/emails/class-ready-for-pickup-email.php
@@ -54,6 +54,7 @@ class Ready_For_Pickup_Email extends WC_Email {
         foreach ( $items as $item_key => $item_value ) {
             // add an event for the item email, pass the item ID so other details can be collected as needed
             wp_schedule_single_event( time(), 'custom_ready_email_trigger', array( 'item_id' => $item_key ) );
+            break;
         }
     }
 

--- a/emails/class-special-email.php
+++ b/emails/class-special-email.php
@@ -55,6 +55,8 @@ class Special_Email extends WC_Email {
         foreach ( $items as $item_key => $item_value ) {
             // add an event for the item email, pass the item ID so other details can be collected as needed
             wp_schedule_single_event( time(), 'custom_special_email_trigger', array( 'item_id' => $item_key ) );
+            // workaround to only send once
+            break;
         }
     }
 

--- a/emails/class-special-email.php
+++ b/emails/class-special-email.php
@@ -16,9 +16,9 @@ class Special_Email extends WC_Email {
         $this->id                   = 'special_email';
         $this->customer_email       = true;         // intended to be sent to customer
         $this->title                = __( 'Special Email', 'special-email' );
-        $this->description          = __( 'This email is sent to cusstomers when an order status is changed to Special.', 'special-email' );
+        $this->description          = __( 'This email is sent to customers when an order status is changed to Special.', 'special-email' );
 
-        $this->heading              = __( 'Special Item Email', 'special-email' );
+        $this->heading              = __( 'Special', 'special-email' );
         $this->subject              = __( '[{blogname}] Order for {product_title} (Order {order_number}) - {order_date}', 'special-email' );
 
         // email template path

--- a/includes/class-woocommerce-custom-emails-manager.php
+++ b/includes/class-woocommerce-custom-emails-manager.php
@@ -17,8 +17,8 @@ class Custom_Email_Manager {
         add_action( 'woocommerce_order_status_example', array( &$this, 'custom_trigger_example_action' ), 10, 2 );
         add_action( 'woocommerce_order_status_finishing', array( &$this, 'custom_trigger_finishing_action' ), 10, 2 );
         add_action( 'woocommerce_order_status_special', array( &$this, 'custom_trigger_special_action' ), 10, 2 );
-        add_action( 'woocommerce_order_status_ready', array( &$this, 'custom_trigger_ready_action' ), 10,
-            2 );
+        add_action( 'woocommerce_order_status_ready', array( &$this, 'custom_trigger_ready_action' ), 10, 2 );
+        add_action( 'woocommerce_order_status_proof', array( &$this, 'custom_trigger_proof_action' ), 10, 2 );
         // include the email class files
         add_filter( 'woocommerce_email_classes', array( &$this, 'custom_init_emails' ) );
 
@@ -31,7 +31,9 @@ class Custom_Email_Manager {
             'custom_special_email',
             'custom_special_email_trigger',
             'custom_ready_email',
-            'custom_ready_email_trigger'
+            'custom_ready_email_trigger',
+            'custom_proof_email',
+            'custom_proof_email_trigger'
         );
 
         foreach ( $email_actions as $action ) {
@@ -58,6 +60,10 @@ class Custom_Email_Manager {
 
         if ( ! isset( $emails['Ready_Email']) ) {
             $emails[ 'Ready_Email' ] = include_once( plugin_dir_path(__DIR__) . 'emails/class-ready-for-pickup-email.php' );
+        }
+
+        if ( ! isset( $emails['Proof_Email']) ) {
+            $emails[ 'Proof_Email' ] = include_once( plugin_dir_path(__DIR__) . 'emails/class-proof-ready-email.php' );
         }
 
         return $emails;
@@ -99,6 +105,16 @@ class Custom_Email_Manager {
 
             WC_Emails::instance();
             do_action( 'custom_ready_email_notification', $order_id );
+
+        }
+    }
+
+    public function custom_trigger_proof_action( $order_id, $posted ) {
+        // add an action for our email trigger if the order id is valid
+        if ( isset( $order_id ) && 0 != $order_id ) {
+
+            WC_Emails::instance();
+            do_action( 'custom_proof_email_notification', $order_id );
 
         }
     }

--- a/includes/class-woocommerce-custom-emails-manager.php
+++ b/includes/class-woocommerce-custom-emails-manager.php
@@ -19,6 +19,7 @@ class Custom_Email_Manager {
         add_action( 'woocommerce_order_status_special', array( &$this, 'custom_trigger_special_action' ), 10, 2 );
         add_action( 'woocommerce_order_status_ready', array( &$this, 'custom_trigger_ready_action' ), 10, 2 );
         add_action( 'woocommerce_order_status_proof', array( &$this, 'custom_trigger_proof_action' ), 10, 2 );
+        add_action( 'woocommerce_order_status_pony', array( &$this, 'custom_trigger_pony_action' ), 10, 2 );
         // include the email class files
         add_filter( 'woocommerce_email_classes', array( &$this, 'custom_init_emails' ) );
 
@@ -33,7 +34,9 @@ class Custom_Email_Manager {
             'custom_ready_email',
             'custom_ready_email_trigger',
             'custom_proof_email',
-            'custom_proof_email_trigger'
+            'custom_proof_email_trigger',
+            'custom_pony_email',
+            'custom_pony_email_trigger'
         );
 
         foreach ( $email_actions as $action ) {
@@ -64,6 +67,10 @@ class Custom_Email_Manager {
 
         if ( ! isset( $emails['Proof_Email']) ) {
             $emails[ 'Proof_Email' ] = include_once( plugin_dir_path(__DIR__) . 'emails/class-proof-ready-email.php' );
+        }
+
+        if ( ! isset( $emails['Pony_Email']) ) {
+            $emails[ 'Pony_Email' ] = include_once( plugin_dir_path(__DIR__) . 'emails/class-pony-email.php' );
         }
 
         return $emails;
@@ -115,6 +122,16 @@ class Custom_Email_Manager {
 
             WC_Emails::instance();
             do_action( 'custom_proof_email_notification', $order_id );
+
+        }
+    }
+
+    public function custom_trigger_pony_action( $order_id, $posted ) {
+        // add an action for our email trigger if the order id is valid
+        if ( isset( $order_id ) && 0 != $order_id ) {
+
+            WC_Emails::instance();
+            do_action( 'custom_pony_email_notification', $order_id );
 
         }
     }

--- a/templates/emails/custom-item-email-html.php
+++ b/templates/emails/custom-item-email-html.php
@@ -10,38 +10,40 @@ $opening_paragraph = __( 'A new order has been made by %s. The details of the it
 <?php do_action( 'woocommerce_email_header', $email_heading ); ?>
 
 <?php
-$billing_first_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_first_name : $order->get_billing_first_name();
-$billing_last_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_last_name : $order->get_billing_last_name();
+$customer = new WC_Customer( $order->get_customer_id() );
+$billing_first_name = $customer->get_first_name();
+$billing_last_name = $customer->get_last_name();
+
 if ( $order && $billing_first_name && $billing_last_name ) : ?>
   <p><?php printf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ); ?></p>
 <?php endif; ?>
 
-  <table cellspacing="0" cellpadding="6" style="width: 100%; border: 1px solid #eee;" border="1" bordercolor="#eee">
-    <tbody>
-    <tr>
-      <th scope="row" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Ordered Product', 'custom-email' ); ?></th>
-      <td style="text-align:left; border: 1px solid #eee;"><?php echo $item_data->product_title; ?></td>
-    </tr>
-    <tr>
-      <th scope="row" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Quantity', 'custom-email' ); ?></th>
-      <td style="text-align:left; border: 1px solid #eee;"><?php echo $item_data->qty; ?></td>
-    </tr>
-    <tr>
-      <th scope="row" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Total', 'custom-email' ); ?></th>
-      <td style="text-align:left; border: 1px solid #eee;"><?php echo $item_data->total; ?></td>
-    </tr>
-    </tbody>
-  </table>
-
-  <p><?php _e( 'This is a custom email sent as the order status has been changed to Pending Payment.', 'custom-email' ); ?></p>
-
 <?php
-/**
-* Show user-defined additional content - this is set in each email's settings.
+/*
+* @hooked WC_Emails::order_details() Shows the order details table.
+* @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+* @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+* @since 2.5.0
 */
-if ( $additional_content ) {
-echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
-}
-?>
+do_action( 'woocommerce_email_order_details', $order );
 
-<?php do_action( 'woocommerce_email_footer' ); ?>
+/*
+* @hooked WC_Emails::order_meta() Shows order meta data.
+*/
+do_action( 'woocommerce_email_order_meta', $order );
+
+/*
+* @hooked WC_Emails::customer_details() Shows customer details
+* @hooked WC_Emails::email_address() Shows email address
+*/
+do_action( 'woocommerce_email_customer_details', $order );
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+    echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+}
+
+do_action( 'woocommerce_email_footer' );
+?>

--- a/templates/emails/finishing-email-html.php
+++ b/templates/emails/finishing-email-html.php
@@ -3,7 +3,7 @@
  * Customer "Finishing" order status email
  */
 $order = new WC_order( $item_data->order_id );
-$opening_paragraph = __( 'The following by %s is finishing! The details of the item are as follows:', 'finishing-email' );
+$opening_paragraph = __( 'The following by %s is finishing! The details of the item are as follows:', 'woocommerce' );
 
 ?>
 
@@ -16,35 +16,32 @@ if ( $order && $billing_first_name && $billing_last_name ) : ?>
     <p><?php printf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ); ?></p>
 <?php endif; ?>
 
-<table cellspacing="0" cellpadding="6" style="width: 100%; border: 1px solid #eee;" border="1" bordercolor="#eee">
-    <tbody>
-    <tr>
-        <th scope="row" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Ordered Product', 'finishing-email' );
-        ?></th>
-        <td style="text-align:left; border: 1px solid #eee;"><?php echo $item_data->product_title; ?></td>
-    </tr>
-    <tr>
-        <th scope="row" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Quantity', 'finishing-email' );
-        ?></th>
-        <td style="text-align:left; border: 1px solid #eee;"><?php echo $item_data->qty; ?></td>
-    </tr>
-    <tr>
-        <th scope="row" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Total', 'finishing-email' );
-        ?></th>
-        <td style="text-align:left; border: 1px solid #eee;"><?php echo $item_data->total; ?></td>
-    </tr>
-    </tbody>
-</table>
-
-<p><?php _e( 'This is an email sent as the order status has been changed to "Finishing".', 'finishing-email' ); ?></p>
-
 <?php
+/*
+* @hooked WC_Emails::order_details() Shows the order details table.
+* @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+* @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+* @since 2.5.0
+*/
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+
+/*
+* @hooked WC_Emails::order_meta() Shows order meta data.
+*/
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+/*
+* @hooked WC_Emails::customer_details() Shows customer details
+* @hooked WC_Emails::email_address() Shows email address
+*/
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+
 /**
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
     echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 }
-?>
 
-<?php do_action( 'woocommerce_email_footer' ); ?>
+do_action( 'woocommerce_email_footer' );
+?>

--- a/templates/emails/finishing-email-html.php
+++ b/templates/emails/finishing-email-html.php
@@ -3,7 +3,7 @@
  * Customer "Finishing" order status email
  */
 $order = new WC_order( $item_data->order_id );
-$opening_paragraph = __( 'The following by %s is finishing! The details of the item are as follows:', 'woocommerce' );
+$opening_paragraph = __( 'An order, made by %s, has now been marked Finishing. The details of the item are as follows:' );
 
 ?>
 

--- a/templates/emails/finishing-email-html.php
+++ b/templates/emails/finishing-email-html.php
@@ -10,8 +10,10 @@ $opening_paragraph = __( 'The following by %s is finishing! The details of the i
 <?php do_action( 'woocommerce_email_header', $email_heading ); ?>
 
 <?php
-$billing_first_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_first_name : $order->get_billing_first_name();
-$billing_last_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_last_name : $order->get_billing_last_name();
+$customer = new WC_Customer( $order->get_customer_id() );
+$billing_first_name = $customer->get_first_name();
+$billing_last_name = $customer->get_last_name();
+
 if ( $order && $billing_first_name && $billing_last_name ) : ?>
     <p><?php printf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ); ?></p>
 <?php endif; ?>

--- a/templates/emails/finishing-email-html.php
+++ b/templates/emails/finishing-email-html.php
@@ -23,18 +23,18 @@ if ( $order && $billing_first_name && $billing_last_name ) : ?>
 * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
 * @since 2.5.0
 */
-do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+do_action( 'woocommerce_email_order_details', $order );
 
 /*
 * @hooked WC_Emails::order_meta() Shows order meta data.
 */
-do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+do_action( 'woocommerce_email_order_meta', $order );
 
 /*
 * @hooked WC_Emails::customer_details() Shows customer details
 * @hooked WC_Emails::email_address() Shows email address
 */
-do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+do_action( 'woocommerce_email_customer_details', $order );
 
 /**
  * Show user-defined additional content - this is set in each email's settings.

--- a/templates/emails/plain/finishing-email-plain.php
+++ b/templates/emails/plain/finishing-email-plain.php
@@ -6,7 +6,7 @@ $order = new WC_order( $item_data->order_id );
 
 echo "= " . $email_heading . " =\n\n";
 
-$opening_paragraph = __( 'The following by %s is finishing! The details of the item are as follows:', 'finishing-email' );
+$opening_paragraph = __( 'An order, made by %s, has now been marked Finishing. The details of the item are as follows:' );
 
 $customer = new WC_Customer( $order->get_customer_id() );
 $billing_first_name = $customer->get_first_name();

--- a/templates/emails/plain/finishing-email-plain.php
+++ b/templates/emails/plain/finishing-email-plain.php
@@ -6,24 +6,26 @@ $order = new WC_order( $item_data->order_id );
 
 echo "= " . $email_heading . " =\n\n";
 
-$opening_paragraph = __( 'The following by %s is finishing! The details of the item are as follows:', 'woocommerce' );
+$opening_paragraph = __( 'The following by %s is finishing! The details of the item are as follows:', 'finishing-email' );
 
-$billing_first_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_first_name : $order->get_billing_first_name();
-$billing_last_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_last_name : $order->get_billing_last_name();
+$customer = new WC_Customer( $order->get_customer_id() );
+$billing_first_name = $customer->get_first_name();
+$billing_last_name = $customer->get_last_name();
+
 if ( $order && $billing_first_name && $billing_last_name ) {
     echo sprintf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ) . "\n\n";
 }
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo sprintf( __( 'Ordered Product: %s', 'woocommerce' ), $item_data->product_title ) . "\n";
+echo sprintf( __( 'Ordered Product: %s', 'finishing-email' ), $item_data->product_title ) . "\n";
 
-echo sprintf( __( 'Quantity: %s', 'woocommerce' ), $item_data->qty ) . "\n";
+echo sprintf( __( 'Quantity: %s', 'finishing-email' ), $item_data->qty ) . "\n";
 
-echo sprintf( __( 'Total: %s', 'woocommerce' ), $item_data->total ) . "\n";
+echo sprintf( __( 'Total: %s', 'finishing-email' ), $item_data->total ) . "\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo __( 'This is an email sent as the order status has been changed to "Finishing".', 'woocommerce' ) . "\n\n";
+echo __( 'This is an email sent as the order status has been changed to "Finishing".', 'finishing-email' ) . "\n\n";
 
 echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );

--- a/templates/emails/plain/finishing-email-plain.php
+++ b/templates/emails/plain/finishing-email-plain.php
@@ -6,7 +6,7 @@ $order = new WC_order( $item_data->order_id );
 
 echo "= " . $email_heading . " =\n\n";
 
-$opening_paragraph = __( 'The following by %s is finishing! The details of the item are as follows:', 'custom-email' );
+$opening_paragraph = __( 'The following by %s is finishing! The details of the item are as follows:', 'woocommerce' );
 
 $billing_first_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_first_name : $order->get_billing_first_name();
 $billing_last_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_last_name : $order->get_billing_last_name();
@@ -16,14 +16,14 @@ if ( $order && $billing_first_name && $billing_last_name ) {
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo sprintf( __( 'Ordered Product: %s', 'custom-email' ), $item_data->product_title ) . "\n";
+echo sprintf( __( 'Ordered Product: %s', 'woocommerce' ), $item_data->product_title ) . "\n";
 
-echo sprintf( __( 'Quantity: %s', 'custom-email' ), $item_data->qty ) . "\n";
+echo sprintf( __( 'Quantity: %s', 'woocommerce' ), $item_data->qty ) . "\n";
 
-echo sprintf( __( 'Total: %s', 'custom-email' ), $item_data->total ) . "\n";
+echo sprintf( __( 'Total: %s', 'woocommerce' ), $item_data->total ) . "\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo __( 'This is an email sent as the order status has been changed to "Finishing".', 'custom-email' ) . "\n\n";
+echo __( 'This is an email sent as the order status has been changed to "Finishing".', 'woocommerce' ) . "\n\n";
 
 echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );

--- a/templates/emails/plain/pony-email-plain.php
+++ b/templates/emails/plain/pony-email-plain.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Customer "Pony" order email
+ */
+$order = new WC_order( $item_data->order_id );
+
+echo "= " . $email_heading . " =\n\n";
+
+$opening_paragraph = __( 'An order, made by %s, has now been marked Pony. The details of the item are as follows:' );
+
+$customer = new WC_Customer( $order->get_customer_id() );
+$billing_first_name = $customer->get_first_name();
+$billing_last_name = $customer->get_last_name();
+
+if ( $order && $billing_first_name && $billing_last_name ) {
+    echo sprintf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ) . "\n\n";
+}
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+echo sprintf( __( 'Ordered Product: %s', 'finishing-email' ), $item_data->product_title ) . "\n";
+
+echo sprintf( __( 'Quantity: %s', 'finishing-email' ), $item_data->qty ) . "\n";
+
+echo sprintf( __( 'Total: %s', 'finishing-email' ), $item_data->total ) . "\n";
+
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+echo __( 'This is an email sent as the order status has been changed to "Finishing".', 'pony-email' ) . "\n\n";
+
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );

--- a/templates/emails/plain/proof-ready-email-plain.php
+++ b/templates/emails/plain/proof-ready-email-plain.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * An email notifying that the order status is now "Proof Ready"
+ */
+$order = new WC_order( $item_data->order_id );
+
+echo "= " . $email_heading . " =\n\n";
+
+$opening_paragraph = __( 'An order, made by %s, has now been marked Proof Ready. The details of the item are as follows:',
+    'proof-ready-email' );
+
+$customer = new WC_Customer( $order->get_customer_id() );
+$billing_first_name = $customer->get_first_name();
+$billing_last_name = $customer->get_last_name();
+
+if ( $order && $billing_first_name && $billing_last_name ) {
+    echo sprintf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ) . "\n\n";
+}
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+echo sprintf( __( 'Ordered Product: %s', 'proof-ready-email' ), $item_data->product_title ) . "\n";
+
+echo sprintf( __( 'Quantity: %s', 'proof-ready-email' ), $item_data->qty ) . "\n";
+
+echo sprintf( __( 'Total: %s', 'proof-ready-email' ), $item_data->total ) . "\n";
+
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+    echo esc_html( wp_strip_all_tags( wptexturize( $additional_content ) ) );
+}
+
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );

--- a/templates/emails/plain/special-email-plain.php
+++ b/templates/emails/plain/special-email-plain.php
@@ -9,8 +9,10 @@ echo "= " . $email_heading . " =\n\n";
 $opening_paragraph = __( 'An order, made by %s, has now been marked Special. The details of the item are as follows:',
     'special-email' );
 
-$billing_first_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_first_name : $order->get_billing_first_name();
-$billing_last_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_last_name : $order->get_billing_last_name();
+$customer = new WC_Customer( $order->get_customer_id() );
+$billing_first_name = $customer->get_first_name();
+$billing_last_name = $customer->get_last_name();
+
 if ( $order && $billing_first_name && $billing_last_name ) {
     echo sprintf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ) . "\n\n";
 }

--- a/templates/emails/pony-email-html.php
+++ b/templates/emails/pony-email-html.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Customer "Pony" order status email
+ */
+$order = new WC_order( $item_data->order_id );
+$opening_paragraph = __( 'An order, made by %s, has now been marked Pony. The details of the item are as follows:' );
+
+?>
+
+<?php do_action( 'woocommerce_email_header', $email_heading ); ?>
+
+<?php
+$customer = new WC_Customer( $order->get_customer_id() );
+$billing_first_name = $customer->get_first_name();
+$billing_last_name = $customer->get_last_name();
+
+if ( $order && $billing_first_name && $billing_last_name ) : ?>
+    <p><?php printf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ); ?></p>
+<?php endif; ?>
+
+<?php
+/*
+* @hooked WC_Emails::order_details() Shows the order details table.
+* @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+* @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+* @since 2.5.0
+*/
+do_action( 'woocommerce_email_order_details', $order );
+
+/*
+* @hooked WC_Emails::order_meta() Shows order meta data.
+*/
+do_action( 'woocommerce_email_order_meta', $order );
+
+/*
+* @hooked WC_Emails::customer_details() Shows customer details
+* @hooked WC_Emails::email_address() Shows email address
+*/
+do_action( 'woocommerce_email_customer_details', $order );
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+    echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+}
+
+do_action( 'woocommerce_email_footer' );
+?>

--- a/templates/emails/proof-ready-email-html.php
+++ b/templates/emails/proof-ready-email-html.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * An email notifying that the order status is now "Proof Ready"
+ */
+$order = new WC_order( $item_data->order_id );
+$opening_paragraph = __( 'An order, made by %s, has now been marked Proof Ready. The details of the item are as follows:' );
+
+?>
+
+<?php do_action( 'woocommerce_email_header', $email_heading ); ?>
+
+<?php
+$customer = new WC_Customer( $order->get_customer_id() );
+$billing_first_name = $customer->get_first_name();
+$billing_last_name = $customer->get_last_name();
+
+if ( $order && $billing_first_name && $billing_last_name ) : ?>
+    <p><?php printf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ); ?></p>
+<?php endif; ?>
+<?php
+/*
+* @hooked WC_Emails::order_details() Shows the order details table.
+* @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+* @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+* @since 2.5.0
+*/
+do_action( 'woocommerce_email_order_details', $order );
+
+/*
+* @hooked WC_Emails::order_meta() Shows order meta data.
+*/
+do_action( 'woocommerce_email_order_meta', $order );
+
+/*
+* @hooked WC_Emails::customer_details() Shows customer details
+* @hooked WC_Emails::email_address() Shows email address
+*/
+do_action( 'woocommerce_email_customer_details', $order );
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+    echo esc_html( wp_strip_all_tags( wptexturize( $additional_content ) ) );
+}
+?>
+
+<?php do_action( 'woocommerce_email_footer' ); ?>

--- a/templates/emails/ready-for-pickup-email-html.php
+++ b/templates/emails/ready-for-pickup-email-html.php
@@ -10,36 +10,33 @@ $opening_paragraph = __( '%s, your order is ready for pick up! The details of th
 <?php do_action( 'woocommerce_email_header', $email_heading ); ?>
 
 <?php
-$billing_first_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_first_name : $order->get_billing_first_name();
-$billing_last_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_last_name : $order->get_billing_last_name();
+$customer = new WC_Customer( $order->get_customer_id() );
+$billing_first_name = $customer->get_first_name();
+$billing_last_name = $customer->get_last_name();
+
 if ( $order && $billing_first_name && $billing_last_name ) : ?>
     <p><?php printf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ); ?></p>
 <?php endif; ?>
 
-<table cellspacing="0" cellpadding="6" style="width: 100%; border: 1px solid #eee;" border="1" bordercolor="#eee">
-    <tbody>
-    <tr>
-        <th scope="row" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Ordered Product', 'ready-for-pickup-email' );
-        ?></th>
-        <td style="text-align:left; border: 1px solid #eee;"><?php echo $item_data->product_title; ?></td>
-    </tr>
-    <tr>
-        <th scope="row" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Quantity', 'ready-for-pickup-email' );
-        ?></th>
-        <td style="text-align:left; border: 1px solid #eee;"><?php echo $item_data->qty; ?></td>
-    </tr>
-    <tr>
-        <th scope="row" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Total', 'ready-for-pickup-email' );
-        ?></th>
-        <td style="text-align:left; border: 1px solid #eee;"><?php echo $item_data->total; ?></td>
-    </tr>
-    </tbody>
-</table>
-
-<p><?php _e( 'This is a custom email sent as the order status has been changed to "Ready for Pick Up".', 'ready-for-pickup-email'
-    ); ?></p>
-
 <?php
+/*
+* @hooked WC_Emails::order_details() Shows the order details table.
+* @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+* @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+* @since 2.5.0
+*/
+do_action( 'woocommerce_email_order_details', $order );
+
+/*
+* @hooked WC_Emails::order_meta() Shows order meta data.
+*/
+do_action( 'woocommerce_email_order_meta', $order );
+
+/*
+* @hooked WC_Emails::customer_details() Shows customer details
+* @hooked WC_Emails::email_address() Shows email address
+*/
+do_action( 'woocommerce_email_customer_details', $order );
 /**
  * Show user-defined additional content - this is set in each email's settings.
  */

--- a/templates/emails/special-email-html.php
+++ b/templates/emails/special-email-html.php
@@ -10,37 +10,33 @@ $opening_paragraph = __( 'An order, made by %s, has now been marked Special. The
 <?php do_action( 'woocommerce_email_header', $email_heading ); ?>
 
 <?php
-$billing_first_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_first_name : $order->get_billing_first_name();
-$billing_last_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order->billing_last_name : $order->get_billing_last_name();
+$customer = new WC_Customer( $order->get_customer_id() );
+$billing_first_name = $customer->get_first_name();
+$billing_last_name = $customer->get_last_name();
+
 if ( $order && $billing_first_name && $billing_last_name ) : ?>
     <p><?php printf( $opening_paragraph, $billing_first_name . ' ' . $billing_last_name ); ?></p>
 <?php endif; ?>
-
-    <table cellspacing="0" cellpadding="6" style="width: 100%; border: 1px solid #eee; color: black;" border="1"
-           bordercolor="#eee">
-        <tbody>
-        <tr>
-            <th scope="row" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Ordered Product', 'special-email'
-                );
-            ?></th>
-            <td style="text-align:left; border: 1px solid #eee;"><?php echo $item_data->product_title; ?></td>
-        </tr>
-        <tr>
-            <th scope="row" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Quantity', 'special-email' );
-            ?></th>
-            <td style="text-align:left; border: 1px solid #eee;"><?php echo $item_data->qty; ?></td>
-        </tr>
-        <tr>
-            <th scope="row" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Total', 'special-email' ); ?></th>
-            <td style="text-align:left; border: 1px solid #eee;"><?php echo $item_data->total; ?></td>
-        </tr>
-        </tbody>
-    </table>
-
-    <p><?php _e( 'This is an email sent as the order status has been changed to "Special".', 'special-email' );
-    ?></p>
-
 <?php
+/*
+* @hooked WC_Emails::order_details() Shows the order details table.
+* @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+* @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+* @since 2.5.0
+*/
+do_action( 'woocommerce_email_order_details', $order );
+
+/*
+* @hooked WC_Emails::order_meta() Shows order meta data.
+*/
+do_action( 'woocommerce_email_order_meta', $order );
+
+/*
+* @hooked WC_Emails::customer_details() Shows customer details
+* @hooked WC_Emails::email_address() Shows email address
+*/
+do_action( 'woocommerce_email_customer_details', $order );
+
 /**
  * Show user-defined additional content - this is set in each email's settings.
  */


### PR DESCRIPTION
This PR creates a new template for a new email. However, this email does not trigger in the same manner as the previous custom email classes; its purpose is to provide a hook for us to call programmatically rather than trigger on status change.

The reason for creating a new email class and its corresponding templates was due to the inconsistency of WooCommerce email hooks. When calling it within our custom hook, some times the new hook fires and sometimes it does not. Will revisit this area one more time before officially committing to this new change.   

**Requirements:**
- [x] "Ready for Pick Up Reminder" emails should provide a hook for us to call from anywhere in our Copy Center application (theme or plugin).
- [x] This new template should not trigger on any order status change.
- [x] Each new email template should have new content to notify customers that it is this is a **reminder** email for orders that are "Ready for Pick Up".
- [ ] There should be a link that allows the user to update their order status to "Complete".